### PR TITLE
Updated doc about CORS suggestion, adding HEAD method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ In order to use this library, you need the following:
          <AllowedMethod>POST</AllowedMethod>
          <AllowedMethod>DELETE</AllowedMethod>
          <AllowedMethod>GET</AllowedMethod>
+         <AllowedMethod>HEAD</AllowedMethod>
          <MaxAgeSeconds>3000</MaxAgeSeconds>
          <AllowedHeader>*</AllowedHeader>
      </CORSRule>


### PR DESCRIPTION
Sometimes PUT to S3 fails, and the code tries to recover from this error by issuing a HEAD to request to the bucket to check if the upload has succeeded or not.
In my bucket I had not included the HEAD method to CORS, so this request was failing and the upload could not recover from the PUT error.
