### PR TITLE
clear interval when different thread completes upload

### DIFF
--- a/mule-uploader.js
+++ b/mule-uploader.js
@@ -413,9 +413,12 @@ function mule_upload(input, settings) {
                 } else {
                     var interval = setInterval(function() {
                         var chunk = u.get_next_chunk();
-                        if(chunk !== -1) {
+                        if(chunk != -1) {
                             clearInterval(interval);
                             u.upload_chunk(chunk);
+                        } else if(u.upload_finished()) {
+                            clearInterval(interval);
+                            u.finish_upload();
                         }
                     }, 1000);
                 }


### PR DESCRIPTION
I noticed that this interval was not being cleared when a different thread completed it's chunk, and the upload, but this interval us unaware the upload is done, keeps trying to get a chunk to upload.

Now it mirrors the code above that runs immediately, but this interval happens each second after that, and clears the intervals either when there is a chunk to process, or the upload is done.
