### PR TITLE
Incorrect chunks array index

### DIFF
--- a/php_backend/example_backend.php
+++ b/php_backend/example_backend.php
@@ -179,9 +179,9 @@ class Backend {
                 if($upload) {
                     $data['key'] = $upload['key'];
                     $data['upload_id'] = $upload['upload_id'];
-                    $data['chunks'] = array_map(
+                    $data['chunks_uploaded'] = array_map(
                         intval,
-                        explode(',', $upload['chunks'])
+                        explode(',', $upload['chunks_uploaded'])
                     );
                 }
             }


### PR DESCRIPTION
In [create_upload](https://github.com/cinely/mule-uploader/blob/master/php_backend/example_backend.php#L66) you were using *chunks_uploaded* but when resuming an upload you're checking for *chunks*. This PR fixes that.