### PR TITLE
Only us-east-1 has different endpoint naming

### DIFF
--- a/mule-uploader.js
+++ b/mule-uploader.js
@@ -1295,7 +1295,7 @@
             // given an AWS region, it either returns an empty string for US-based regions
             // or the region name preceded by a dash for non-US-based regions
             // see this for more details: http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html
-            if(region && region.slice(0,2) !== 'us') {
+            if(region && region !== 'us-east-1') {
                 return '-' + region;
             }
             return '';


### PR DESCRIPTION
During testing with a region on us-west-2 I kept getting a signature mismatch error. Using the endpoint s3-us-west-2.amazonaws.com fixed the issue. Also according to the [docs] (http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) I think the s3.amazonaws.com endpoint is only valid for us-east-1. Why there isn't a s3-us-east-1.amazonaws.com endpoint is beyond me.