### PR TITLE
Add support for cancelling upload in on_select

### DIFF
--- a/mule-uploader.js
+++ b/mule-uploader.js
@@ -314,7 +314,12 @@
             }
 
             // initialize the file upload
-            u.settings.on_select.call(u, file);
+            try {
+                u.settings.on_select.call(u, file);
+            } catch(error) {
+                alert(error);
+                return false;
+            }
 
             var args = utils.extend_object(u.settings.extra_params || {}, {
                 filename: file.name,
@@ -712,7 +717,7 @@
             var key = u.settings.key;
             var upload_id = u.upload_id;
             var url = u.settings.ajax_base + '/chunk_loaded/';
-            
+
             var args = utils.extend_object(u.settings.extra_params || {}, {
                 chunk: chunk,
                 key: key,


### PR DESCRIPTION
This PR allows you to do stuff like:
```javascript
on_select: function(fileObj) {
    if ( fileObj.name.match(/[a-zA-Z0-9\._-]+/g).length != 1 )
        throw "You can only upload filenames with letters, numbers, underscores and dashes. Please remove any quotes, spaces etc.";

    ....
}
```

This will make an error appear on upload in the same way one would appear if you didn't meet the file extension requirements.