### PR TITLE
Fix attachment header to support accentuated filename

### DIFF
--- a/mule-uploader.js
+++ b/mule-uploader.js
@@ -1096,7 +1096,7 @@
             },
             headers: {
                 "x-amz-acl": "public-read",
-                "Content-Disposition": "attachment; filename=" + file.name,
+                "Content-Disposition": "attachment; filename=" + encodeURIComponent(file.name),
                 "Content-Type": auth.content_type || "application/octet-stream"
             },
             payload: "",


### PR DESCRIPTION
File like "vidéo 1 vacances été 2015.mov" were generating an invalid header error.