### PR TITLE
add content_type in signing request

### DIFF
--- a/mule-uploader.js
+++ b/mule-uploader.js
@@ -319,6 +319,7 @@
             var args = utils.extend_object(u.settings.extra_params || {}, {
                 filename: file.name,
                 filesize: file.size,
+                content_type: file.type,
                 last_modified: file.lastModifiedDate.valueOf()
             });
 


### PR DESCRIPTION
synchronise client and backend enabling real content_type support.
this allows amazon objects to be set with a precise mime type while
avoiding desync between client and backend which makes the signing fail.