### PR TITLE
UTC in the front, UTC in the back – 403 status solution?

### DIFF
--- a/example_backend.py
+++ b/example_backend.py
@@ -92,7 +92,7 @@ def signing_key():
     last_modified = request.args['last_modified']
 
     data = {
-        "date": date.isoformat(),
+        "date": date.isoformat() + 'Z',
         "signature": key,
         "access_key": AWS_ACCESS_KEY,
         "region": AWS_REGION,

--- a/mule-uploader.js
+++ b/mule-uploader.js
@@ -337,7 +337,8 @@
                 extra_params: args,
                 load_callback: function(e) {
                     var json = JSON.parse(e.target.responseText);
-                    json.date = new Date(json.date);
+                    var utc_suffix = /Z$/.test(json.date.toString()) ? '' : 'Z';
+                    json.date = new Date(json.date + utc_suffix);
                     u.auth = json;
                     u.upload_id = json.upload_id;
                     u.chunks = json.chunks;


### PR DESCRIPTION
Hello gents,

I've been having problems with uploading files from different places on earth (different timezones). The problems were mainly about users getting **403** statuses from S3 (invalid signature or something).

Here's something I came up with – the theory:

In python…
```python
from datetime import datetime
datetime.utcnow().isoformat()
# "2016-04-29T22:41:32.190085"
```
Now, I'm taking this string to the browser. In js console I type:
```javascript
new Date("2016-04-29T22:41:32.190085").toUTCString()
// "Fri, 29 Apr 2016 20:41:32 GMT"
```

I'm `GMT+200` and somehow I just lost 2 hours here. 22:41 UTC is 20:41 UTC now…

—

### **tl;dr**

> Z is the zone designator for the zero UTC offset.
> — https://en.wikipedia.org/wiki/ISO_8601

In this Pull Request I do 2 things:

1. Append `Z` to `date.isoformat()`, because it's UTC and it's a good thing to say so explicitly (`isoformat` doesn't do it)
2. For peeps who don't use python backend from this repo I tell javascript to check if there's `Z` at the end of what the backend returns. If not I append one to ensure js is also working with UTC stuff.

Hope you like it and hope it solves problems, not causes them. ;) Please let me know what you think; merge if you like it.

Cheers,
Mariusz