### PR TITLE
Double slash in path

### DIFF
--- a/src/mule-uploader.js
+++ b/src/mule-uploader.js
@@ -713,7 +713,7 @@
         Uploader.prototype.check_already_uploaded = function(callback, error_callback) {
             var u = this;
             var method = "HEAD";
-            var path = "/" + u.settings.key;
+            var path = u.settings.key;
             var inner_handler = function(e) {
                 // the handler only checks for status code;
                 // if the HEAD returns 404, re-upload,


### PR DESCRIPTION
Unnecessary slash added both to the path var and in the string concatenation.